### PR TITLE
Update schema for lte names

### DIFF
--- a/devicemap-schema.json
+++ b/devicemap-schema.json
@@ -84,7 +84,7 @@
           "properties": {
             "name": {
               "type": "string",
-              "pattern": "^lte-[0-9]+$"
+              "pattern": "^lte-[0-9]+(-[0-9]+)?$"
             },
             "type": {
               "type": "string",


### PR DESCRIPTION
schema now accepts `lte-x-y` instead of just `lte-x`