### PR TITLE
changed 1515 skus to generic NCA-1515

### DIFF
--- a/devicemaps.json
+++ b/devicemaps.json
@@ -221,7 +221,7 @@
       }
     },
     "Lanner": {
-      "NCA-1515A-128T": {
+      "NCA-1515": {
         "ethernet": [
           {
             "pciAddress": "0000:02:00.0",
@@ -342,12 +342,6 @@
             }
           }
         ]
-      },
-      "NCA-1515B-128T": {
-        "alias": {
-          "vendor": "Lanner",
-          "sku": "NCA-1515A-128T"
-        }
       }
     },
     "Juniper": {


### PR DESCRIPTION
We're adding support for `startswith` in the HWB. This means that `NCA-1515A-128T` will match with the `NCA-1515` sku entry in the device-map