### PR TITLE
Make Silicom devices more specific

### DIFF
--- a/devicemaps.json
+++ b/devicemaps.json
@@ -88,7 +88,7 @@
         "description": "Madrid - 6 ethernet, 1 lte",
         "alias": {
           "vendor": "Silicom",
-          "sku": "90500-0151-G"
+          "sku": "90500-0151-"
         },
         "lte": [
           {
@@ -116,7 +116,7 @@
         "description": "Madrid - 6 ethernet, 2 lte",
         "alias": {
           "vendor": "Silicom",
-          "sku": "90500-0151-G"
+          "sku": "90500-0151-"
         },
         "lte": [
           {

--- a/devicemaps.json
+++ b/devicemaps.json
@@ -1,7 +1,7 @@
 {
   "interfaceMap": {
     "Silicom": {
-      "90500-0151-G61": {
+      "90500-0151-G": {
         "ethernet": [
           {
             "pciAddress": "0000:02:00.1",
@@ -81,7 +81,13 @@
               }
             }
           }
-        ],
+        ]
+      },
+      "90500-0151-G11": {
+        "alias": {
+          "vendor": "Silicom",
+          "sku": "90500-0151-G"
+        },
         "lte": [
           {
             "targetInterface": "wwp0s21u1i8",
@@ -97,8 +103,45 @@
           }
         ]
       },
-      "90500-0151-": {
-        "description": "Madrid Platforms",
+      "90500-0151-G61": {
+        "alias": {
+          "vendor": "Silicom",
+          "sku": "90500-0151-G11"
+        }
+      },
+      "90500-0151-G71": {
+        "alias": {
+          "vendor": "Silicom",
+          "sku": "90500-0151-G"
+        },
+        "lte": [
+          {
+            "targetInterface": "wwp0s21u1i8",
+            "type": "WAN",
+            "name": "lte-0-0",
+            "description": "LTE device interface",
+            "bcpNetwork": {
+              "standaloneBranch": {
+                "name": "lte-0-0",
+                "description": "LTE network interface"
+              }
+            }
+          },
+          {
+            "targetInterface": "wwp0s21u3i8",
+            "type": "WAN",
+            "name": "lte-0-1",
+            "description": "LTE device interface",
+            "bcpNetwork": {
+              "standaloneBranch": {
+                "name": "lte-0-1",
+                "description": "LTE network interface"
+              }
+            }
+          }
+        ]
+      },
+      "90500-0151-G53": {
         "ethernet": [
           {
             "pciAddress": "0000:02:00.1",

--- a/devicemaps.json
+++ b/devicemaps.json
@@ -1,7 +1,8 @@
 {
   "interfaceMap": {
     "Silicom": {
-      "90500-0151-G": {
+      "90500-0151-": {
+        "description": "Madrid - 6 ethernet",
         "ethernet": [
           {
             "pciAddress": "0000:02:00.1",
@@ -84,6 +85,7 @@
         ]
       },
       "90500-0151-G11": {
+        "description": "Madrid - 6 ethernet, 1 lte",
         "alias": {
           "vendor": "Silicom",
           "sku": "90500-0151-G"
@@ -104,12 +106,14 @@
         ]
       },
       "90500-0151-G61": {
+        "description": "Madrid - 6 ethernet, 1 lte",
         "alias": {
           "vendor": "Silicom",
           "sku": "90500-0151-G11"
         }
       },
       "90500-0151-G71": {
+        "description": "Madrid - 6 ethernet, 2 lte",
         "alias": {
           "vendor": "Silicom",
           "sku": "90500-0151-G"
@@ -142,6 +146,7 @@
         ]
       },
       "90500-0151-G53": {
+        "description": "Madrid - 8 ethernet, 1 lte",
         "ethernet": [
           {
             "pciAddress": "0000:02:00.1",


### PR DESCRIPTION
`G01` and `G02` have 6 ports and 0 LTE intfs
`G11` and `G61` have 6 ports and 1 LTE intf
`G71` has 6 ports and 2 LTE intfs

`G53` has 8 ports & 1 lte

So...
- Generalize the `G01` and `G02` cases with `-` prefixes
- Alias `G11` to the `-G` prefix and add lte intf
- Alias `G61` to `G11`
- Alias `G71` to the `-G` prefix and add 2 lte intfs
- `G53` gets its own entry