### PR TITLE
Add source field to schema

### DIFF
--- a/devicemap-schema.json
+++ b/devicemap-schema.json
@@ -122,6 +122,9 @@
           "sku"
         ],
         "additionalProperties": false
+      },
+      "source": {
+        "type": "string"
       }
     },
     "additionalProperties": false,


### PR DESCRIPTION
If this field is set to `bootstrapper` we will remove the devicemap on factory reset