### PR TITLE
Update devicemaps.json to include LTE section for Silicom Madrid 90500-0151-G12 model

### DIFF
--- a/devicemaps.json
+++ b/devicemaps.json
@@ -105,6 +105,27 @@
           }
         ]
       },
+      "90500-0151-G12": {
+        "description": "Madrid - 6 ethernet, 1 lte",
+        "alias": {
+          "vendor": "Silicom",
+          "sku": "90500-0151-G12"
+        },
+        "lte": [
+          {
+            "targetInterface": "wwp0s21u1i8",
+            "type": "WAN",
+            "name": "lte-0-0",
+            "description": "LTE device interface",
+            "bcpNetwork": {
+              "standaloneBranch": {
+                "name": "lte-0-0",
+                "description": "LTE network interface"
+              }
+            }
+          }
+        ]
+      },
       "90500-0151-G61": {
         "description": "Madrid - 6 ethernet, 1 lte",
         "alias": {

--- a/devicemaps.json
+++ b/devicemaps.json
@@ -109,22 +109,8 @@
         "description": "Madrid - 6 ethernet, 1 lte",
         "alias": {
           "vendor": "Silicom",
-          "sku": "90500-0151-G12"
+          "sku": "90500-0151-G11"
         },
-        "lte": [
-          {
-            "targetInterface": "wwp0s21u1i8",
-            "type": "WAN",
-            "name": "lte-0-0",
-            "description": "LTE device interface",
-            "bcpNetwork": {
-              "standaloneBranch": {
-                "name": "lte-0-0",
-                "description": "LTE network interface"
-              }
-            }
-          }
-        ]
       },
       "90500-0151-G61": {
         "description": "Madrid - 6 ethernet, 1 lte",

--- a/devicemaps.json
+++ b/devicemaps.json
@@ -110,7 +110,7 @@
         "alias": {
           "vendor": "Silicom",
           "sku": "90500-0151-G11"
-        },
+        }
       },
       "90500-0151-G61": {
         "description": "Madrid - 6 ethernet, 1 lte",


### PR DESCRIPTION
Including LTE section for Silicom Madrid 90500-0151-G12 model. Jira for tracking: https://128technology.atlassian.net/browse/WAN-1959