### PR TITLE
Add platform capabilities for Leopard models

### DIFF
--- a/devicemap-schema.json
+++ b/devicemap-schema.json
@@ -14,6 +14,18 @@
     "description": {
       "type": "string"
     },
+    "platform-capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "recovery-mode",
+          "disable-reset-button",
+          "no-pci-on-forwarding-interfaces",
+          "interface-name-on-forwarding-interfaces"
+        ]
+      }
+    },
     "clei": {
       "type": "string"
     },

--- a/devicemap-schema.json
+++ b/devicemap-schema.json
@@ -14,13 +14,13 @@
     "description": {
       "type": "string"
     },
-    "platform-capabilities": {
+    "platformCapabilities": {
       "type": "array",
       "items": {
         "type": "string",
         "enum": [
           "recovery-mode",
-          "disable-reset-button",
+          "reset-button",
           "no-pci-on-forwarding-interfaces",
           "interface-name-on-forwarding-interfaces"
         ]

--- a/devicemaps.json
+++ b/devicemaps.json
@@ -1468,9 +1468,9 @@
         "part_number": "650-178218",
         "deviceType": "juniper-manufactured",
         "description": "Juniper SSR400 - 10 ethernet ports",
-        "platform-capabilities": [
+        "platformCapabilities": [
           "recovery-mode",
-          "disable-reset-button",
+          "reset-button",
           "no-pci-on-forwarding-interfaces",
           "interface-name-on-forwarding-interfaces"
         ],

--- a/devicemaps.json
+++ b/devicemaps.json
@@ -1468,6 +1468,12 @@
         "part_number": "650-178218",
         "deviceType": "juniper-manufactured",
         "description": "Juniper SSR400 - 10 ethernet ports",
+        "platform-capabilities": [
+          "recovery-mode",
+          "disable-reset-button",
+          "no-pci-on-forwarding-interfaces",
+          "interface-name-on-forwarding-interfaces"
+        ],
         "ethernet": [
           {
             "type": "SWITCH_PARENT",


### PR DESCRIPTION
### Description
Add platform capabilities for Leopard models. All other variants of Leopard model 1 and 2 are aliased back to the base `SSR400` so they will inherit the same platform capabilities. Leopard models 3 and 4 are not present in `devicemap.json` yet.

These platforms capabilities are tied into the platform specific datamodel feature. They will be loaded by the config director and used to populate a hidden `platform-capabilities` field on a per node basis using the detected `platform-type` of the node. The values in the `platform-capabilities` will be used with `when` conditions to enable or disable the usage of certain configuration fields on a per model basis.
